### PR TITLE
Fix .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ os: osx
 osx_image: xcode7.3
 
 install:
-  - [[ ! -f ~/sbt ]] && \
-    curl -s https://raw.githubusercontent.com/paulp/sbt-extras/e428bbdb514e1ffe245010b3c4f69e9dfa4bbdb3/sbt > ~/sbt && \
-    chmod 0755 ~/sbt
+  - "[[ ! -f ~/sbt ]] && curl -s https://raw.githubusercontent.com/paulp/sbt-extras/e428bbdb514e1ffe245010b3c4f69e9dfa4bbdb3/sbt > ~/sbt && chmod 0755 ~/sbt"
   - java -version
 
 cache:


### PR DESCRIPTION
Added double quotes around the command. This is done in order to interpret the Bash condition properly else it's interpreted as a YAML array.
